### PR TITLE
Refactor Code's method argument to &str for compatibility with external storage

### DIFF
--- a/src/code.rs
+++ b/src/code.rs
@@ -148,9 +148,9 @@ impl Code {
     /// If valid, returns a `Code`; otherwise, returns `Error::CSRFNotMatch`.
     pub fn new_with_verify_csrf(
         res: UnCheckedCodeResponse,
-        csrf_token: CSRFToken,
+        csrf_token_val: &str,
     ) -> Result<Self, Error> {
-        if res.state.0 == csrf_token.0 {
+        if res.state.0 == csrf_token_val {
             Ok(res.code)
         } else {
             Err(Error::CSRFNotMatch)


### PR DESCRIPTION
## Summary
The argument type for ```Code::new_with_verify_csrf```  has been changed from CSRFToken to &str.
This change allows compatibility with external storage, such as Redis, which cannot handle Rust-specific types.

## Changes
Changed the argument type for new_with_verify_csrf from CSRFToken to &str

## Impact
Code that uses exchange_with_code needs to pass &str instead of CSRFToken
All existing tests have passed successfully (new tests have been added as well)
## Related Issue
Closes https://github.com/nakaryo716/tiny_google_oidc/issues/1
