### PR TITLE
V0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -112,6 +118,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "backon"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "970d91570c01a8a5959b36ad7dd1c30642df24b6b3068710066f6809f7033bb7"
+dependencies = [
+ "fastrand",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -170,6 +185,20 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+]
 
 [[package]]
 name = "cookie"
@@ -307,6 +336,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,9 +365,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -792,10 +835,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "object"
@@ -1055,6 +1126,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "redis"
+version = "0.29.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc42f3a12fd4408ce64d8efef67048a924e543bd35c6591c0447fda9054695f"
+dependencies = [
+ "arc-swap",
+ "backon",
+ "bytes",
+ "combine",
+ "futures-channel",
+ "futures-util",
+ "itoa",
+ "num-bigint",
+ "percent-encoding",
+ "pin-project-lite",
+ "ryu",
+ "sha1_smol",
+ "socket2",
+ "tokio",
+ "tokio-util",
+ "url",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1299,6 +1394,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1493,15 +1594,24 @@ dependencies = [
  "axum",
  "axum-extra",
  "base64",
+ "bytes",
+ "cookie",
  "dotenvy",
+ "futures-util",
  "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
  "itertools",
  "rand 0.9.0",
+ "redis",
  "reqwest",
  "serde",
  "serde_json",
  "thiserror",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
  "url",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,9 +43,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "axum"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d6fd624c75e18b3b4c6b9caf42b1afe24437daaee904069137d8bab077be8b8"
+checksum = "de45108900e1f9b9242f7f2e254aa3e2c029c921c258fe9e6b4217eeebd54288"
 dependencies = [
  "axum-core",
  "bytes",
@@ -77,12 +77,12 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1362f362fd16024ae199c1970ce98f9661bf5ef94b9808fee734bc3698b733"
+checksum = "68464cd0412f486726fb3373129ef5d2993f90c34bc2bc1c1e9943b2f4fc7ca6"
 dependencies = [
  "bytes",
- "futures-util",
+ "futures-core",
  "http",
  "http-body",
  "http-body-util",
@@ -1588,7 +1588,7 @@ dependencies = [
 
 [[package]]
 name = "tiny_google_oidc"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,11 +28,24 @@ uuid = { version = "1.16.0", features = ["v4", "fast-rng"] }
 anyhow = "1.0.97"
 axum = "0.8.1" 
 axum-extra = { version = "0.10.0", features = ["cookie"] }
+bytes = "1"
 dotenvy = "0.15.7"
+cookie = "0.18"
 http = "1.3.1"
+hyper ={ version = "1", features = ["server"]}
+hyper-util ={ version = "^0.1", features = ["full"] }
+http-body = "1"
+http-body-util = "0.1"
+redis = { version = "0.29.2", features = ["tokio-comp", "aio", "connection-manager"]}
 tokio = { version = "1.44.1", features = ["full"] }
+tokio-util = { version = "0.7.14", features = ["io"]}
 tracing-subscriber = "0.3.19"
+futures-util = "0.3.31"
 
 [[example]]
 name = "axum_server"
 path = "examples/axum_server.rs"
+
+[[example]]
+name = "hyper"
+path = "examples/hyper/main.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiny_google_oidc"
-version = "0.2.0"
+version = "0.3.0"
 readme = "README.md"
 repository = "https://github.com/nakaryo716/tiny_google_oidc.git" 
 license = "MIT" 
@@ -12,35 +12,34 @@ keywords = ["oidc", "Authentication", "web-programming"]
 edition = "2024"
 
 [dependencies]
-base64 = "0.22.1"
-http = "1.3.1"
-itertools = "0.14.0"
-rand = "0.9.0"
-reqwest = { version = "0.12.15", features = ["json", "rustls-tls"] }
-serde = { version = "1.0.219", features = ["derive"] }
-serde_json = "1.0.140"
-thiserror = "2.0.12"
-tracing = "0.1.41"
-url = "2.5.4"
-uuid = { version = "1.16.0", features = ["v4", "fast-rng"] }
+base64 = "0.22"
+http = "1"
+itertools = "0.14"
+rand = "0.9"
+reqwest = { version = "0.12", features = ["json", "rustls-tls"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "2"
+tracing = "0.1"
+url = "2"
+uuid = { version = "1", features = ["v4", "fast-rng"] }
 
 [dev-dependencies]
-anyhow = "1.0.97"
-axum = "0.8.1" 
-axum-extra = { version = "0.10.0", features = ["cookie"] }
+anyhow = "1"
+axum = "0.8" 
+axum-extra = { version = "0.10", features = ["cookie"] }
 bytes = "1"
 dotenvy = "0.15.7"
 cookie = "0.18"
-http = "1.3.1"
 hyper ={ version = "1", features = ["server"]}
-hyper-util ={ version = "^0.1", features = ["full"] }
+hyper-util ={ version = "0.1", features = ["full"] }
 http-body = "1"
 http-body-util = "0.1"
 redis = { version = "0.29.2", features = ["tokio-comp", "aio", "connection-manager"]}
-tokio = { version = "1.44.1", features = ["full"] }
-tokio-util = { version = "0.7.14", features = ["io"]}
-tracing-subscriber = "0.3.19"
-futures-util = "0.3.31"
+tokio = { version = "1", features = ["full"] }
+tokio-util = { version = "0.7", features = ["io"]}
+tracing-subscriber = "0.3"
+futures-util = "0.3"
 
 [[example]]
 name = "axum_server"

--- a/examples/axum_server.rs
+++ b/examples/axum_server.rs
@@ -28,7 +28,7 @@ use axum_extra::extract::{CookieJar, cookie::Cookie};
 use http::{StatusCode, header::HOST};
 use serde::Deserialize;
 use tiny_google_oidc::{
-    code::{AdditionalScope, CodeRequest, UnCheckedCodeResponse},
+    code::{AccessType, AdditionalScope, CodeRequest, UnCheckedCodeResponse},
     config::{Config, ConfigBuilder},
     csrf_token::CSRFToken,
     executer::{Executer, IDTokenExe, RefreshTokenExe, RevokeTokenExe},
@@ -108,7 +108,7 @@ async fn start_auth(
     let scope = Some([AdditionalScope::Email, AdditionalScope::Profile].into_iter());
 
     // Construct CodeRequest from config, scope, csrf_token, nonce
-    let req = CodeRequest::new(true, &app_state.config, scope, &state, &nonce);
+    let req = CodeRequest::new(AccessType::Offline, &app_state.config, scope, &state, &nonce);
     // Convert as URL
     let url = req
         .into_url()

--- a/examples/axum_server.rs
+++ b/examples/axum_server.rs
@@ -105,7 +105,7 @@ async fn start_auth(
     }
     // Generate Nonce
     let nonce = Nonce::new();
-    let scope = Some([AdditionalScope::Email, AdditionalScope::Profile].into_iter());
+    let scope = Some([AdditionalScope::Email, AdditionalScope::Profile]);
 
     // Construct CodeRequest from config, scope, csrf_token, nonce
     let req = CodeRequest::new(AccessType::Offline, &app_state.config, scope, &state, &nonce);

--- a/examples/hyper/compose.yaml
+++ b/examples/hyper/compose.yaml
@@ -1,0 +1,9 @@
+services:
+  redis:
+    image: redis:latest
+    ports:
+      - 6379:6379
+    volumes:
+      - redis-volumes:/data
+volumes:
+  redis-volumes:

--- a/examples/hyper/index.html
+++ b/examples/hyper/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>RootPage</title>
+</head>
+<body>
+    <p><a href="http://localhost/auth">Login</a></p>
+    <p><a href="http://localhost/protected">Protected Page</a></p>
+</body>
+</html>

--- a/examples/hyper/login_service.rs
+++ b/examples/hyper/login_service.rs
@@ -1,0 +1,169 @@
+use std::sync::Arc;
+
+use bytes::Bytes;
+use cookie::{Cookie, CookieBuilder, SameSite};
+use http::{
+    header::{COOKIE, HOST, LOCATION, SET_COOKIE}, HeaderValue, Request, Response, StatusCode
+};
+use http_body_util::{BodyExt, Empty, combinators::BoxBody};
+use hyper::body::Incoming;
+use redis::{aio::ConnectionManager, cmd};
+use tiny_google_oidc::{
+    code::{AdditionalScope, CodeRequest, UnCheckedCodeResponse},
+    config::Config,
+    csrf_token::CSRFToken,
+    executer::{Executer, IDTokenExe},
+    id_token::{IDToken, IDTokenRequest},
+    nonce::Nonce,
+};
+use uuid::Uuid;
+
+use crate::protected::see_location_res;
+
+static CSRF_COOKIE_KEY: &str = "csrf_key";
+pub static SESSION_COOKIE_KEY: &str = "session";
+
+#[derive(Clone)]
+pub struct LoginService {
+    config: Arc<Config>,
+    redis_conn: ConnectionManager,
+}
+
+impl LoginService {
+    pub fn new(config: Arc<Config>, redis_conn: ConnectionManager) -> Self {
+        Self { config, redis_conn }
+    }
+
+    // A service that starts login when the login button is pressed on Google
+    pub async fn entry(&mut self) -> anyhow::Result<Response<BoxBody<Bytes, std::io::Error>>> {
+        // gen CSRFToken
+        let csrf_token = CSRFToken::new()?;
+        // Create a KEY to store the CSRFToken
+        let csrf_key = Uuid::new_v4().to_string();
+        // Create Cookie
+        let cookie = CookieBuilder::new(CSRF_COOKIE_KEY, csrf_key.clone())
+            .same_site(SameSite::Lax)
+            .http_only(true)
+            .build();
+
+        // Specify the OpenId Connect scope
+        // Specify that the email and username should be included in the ID token
+        let scope = Some([AdditionalScope::Email, AdditionalScope::Profile].into_iter());
+
+        // Store CSRF token in Redis
+        let _ = cmd("SET")
+            .arg(&csrf_key)
+            .arg(csrf_token.value())
+            .query_async::<String>(&mut self.redis_conn)
+            .await?;
+
+        // Generate CodeRequest and make it into URL
+        let url =
+            CodeRequest::new(false, &self.config, scope, &csrf_token, &Nonce::new()).into_url()?;
+
+        let res = Response::builder()
+            .status(StatusCode::SEE_OTHER)
+            .header(LOCATION, url)
+            .header(SET_COOKIE, cookie.to_string())
+            .body(Empty::new().map_err(|e| match e {}).boxed())
+            .unwrap();
+        Ok(res)
+    }
+
+    pub async fn callback(
+        &mut self,
+        req: Request<Incoming>,
+    ) -> anyhow::Result<Response<BoxBody<Bytes, std::io::Error>>> {
+        let cookie_header_val = match req.headers().get(COOKIE) {
+            Some(v) => v,
+            None => return Ok(see_location_res("/")),
+        };
+        let cookies = Self::parse_cookies(&cookie_header_val)?;
+
+        // Get the CSRFToken key stored in Redis from the cookie
+        let csrf_key = match cookies.iter().find(|c| c.name() == CSRF_COOKIE_KEY) {
+            Some(cookie) => cookie.value(),
+            None => return Ok(see_location_res("/")),
+        };
+        // Get CSRFToken from Redis
+        let csrf_token = cmd("GET")
+            .arg(&csrf_key)
+            .query_async::<String>(&mut self.redis_conn)
+            .await?;
+
+        // Create Full path URL
+        let host = req
+            .headers()
+            .get(HOST)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("localhost");
+        let path = req
+            .uri()
+            .path_and_query()
+            .map(|pq| pq.as_str())
+            .unwrap_or("/");
+        let scheme = "http";
+        let url = format!("{}://{}{}", scheme, host, path);
+
+        // Create UncheckedCodeResponse from url
+        let code_res = UnCheckedCodeResponse::from_url(&url)?;
+        // Consume the response and get the code
+        // Verify that the CSRFToken matches (Error if they do not match)
+        let code = code_res.exchange_with_code(&csrf_token)?;
+
+        // Send an HTTP Request to Google to get an IDToken
+        // Use the code (CSRFToken has been verified by exchange_with_code)
+        let id_token_res = IDTokenExe
+            .execute(&IDTokenRequest::new(&self.config, code))
+            .await?;
+
+        // It is also possible to obtain an AccessToken or RefreshToken.
+        // This needs to be stored in a secure database.
+        let _access_token = id_token_res.access_token();
+        let _refresh_token = id_token_res.refresh_token();
+
+        // Get IDToken(Decode)
+        let id_token = IDToken::decode_from_row(id_token_res.id_token())?;
+
+        // Create SessionID
+        let session_id = Uuid::new_v4().to_string();
+
+        // Save the SessionID and the sub of the IDToken structure (which is the identifier) ​​as the value in Redis.
+        let _ = cmd("SET")
+            .arg(&session_id)
+            .arg(&id_token.sub)
+            .query_async::<String>(&mut self.redis_conn)
+            .await?;
+
+        // Delete CSRFToken that used
+        let _ = cmd("DEL")
+            .arg(&csrf_key)
+            .query_async::<String>(&mut self.redis_conn)
+            .await?;
+
+        // Create cookie to store SessionID
+        let new_cookie = CookieBuilder::new(SESSION_COOKIE_KEY, session_id)
+            .same_site(SameSite::Lax)
+            .http_only(true)
+            .path("/")
+            .build();
+
+        let res = Response::builder()
+            .status(StatusCode::SEE_OTHER)
+            .header(SET_COOKIE, new_cookie.to_string())
+            .header(LOCATION, "/protected")
+            .body(Empty::new().map_err(|e| match e {}).boxed())
+            .unwrap();
+        Ok(res)
+    }
+
+    fn parse_cookies(header_val: &HeaderValue) -> anyhow::Result<Vec<Cookie<'_>>> {
+        let values = header_val.to_str()?;
+
+        let cookies: Vec<Cookie<'_>> = values
+            .split(';')
+            .filter_map(|c| Cookie::parse(c.trim().to_string()).ok())
+            .collect();
+        Ok(cookies)
+    }
+}

--- a/examples/hyper/login_service.rs
+++ b/examples/hyper/login_service.rs
@@ -9,7 +9,7 @@ use http_body_util::{BodyExt, Empty, combinators::BoxBody};
 use hyper::body::Incoming;
 use redis::{aio::ConnectionManager, cmd};
 use tiny_google_oidc::{
-    code::{AdditionalScope, CodeRequest, UnCheckedCodeResponse},
+    code::{AccessType, AdditionalScope, CodeRequest, UnCheckedCodeResponse},
     config::Config,
     csrf_token::CSRFToken,
     executer::{Executer, IDTokenExe},
@@ -48,7 +48,7 @@ impl LoginService {
 
         // Specify the OpenId Connect scope
         // Specify that the email and username should be included in the ID token
-        let scope = Some([AdditionalScope::Email, AdditionalScope::Profile].into_iter());
+        let scope = Some([AdditionalScope::Email, AdditionalScope::Profile]);
 
         // Store CSRF token in Redis
         let _ = cmd("SET")
@@ -59,7 +59,7 @@ impl LoginService {
 
         // Generate CodeRequest and make it into URL
         let url =
-            CodeRequest::new(false, &self.config, scope, &csrf_token, &Nonce::new()).into_url()?;
+            CodeRequest::new(AccessType::Offline, &self.config, scope, &csrf_token, &Nonce::new()).into_url()?;
 
         let res = Response::builder()
             .status(StatusCode::SEE_OTHER)

--- a/examples/hyper/main.rs
+++ b/examples/hyper/main.rs
@@ -1,0 +1,106 @@
+// This example is implementation of login and session
+// by using hyper
+//
+// # Run
+// ## Oauth settings in cloud console 
+// At first, you should set up Oauth settings in Google cloud console
+// Inside setting page, set parameter like this
+// - Origin JavascriptURL: http://localhost
+// - RedirectURL: http://localhost/auth/callback
+// 
+// ## Run Redis
+// Run redis container
+// In ./examples/hyper directory,
+// ```docker compose up```
+//
+// ## Run application 
+// ```cargo run --example hyper```
+// ## Access
+// You can access http://localhost/
+use std::{
+    net::{Ipv4Addr, SocketAddrV4}, sync::Arc, time::Duration
+};
+
+use hyper::server::conn::http1;
+use hyper_util::rt::TokioIo;
+use redis::aio::ConnectionManager;
+use router::Router;
+use tiny_google_oidc::config::ConfigBuilder;
+use tracing::{error, info};
+
+mod protected;
+mod router;
+mod login_service;
+
+static REDIS_URL: &str = "redis://localhost:6379";
+static PORT: u16 = 80;
+// Google OpenID Connect
+// Change me according to client_secret.json that is downloaded
+// auth_endpoint
+static AUTH_ENDPOINT: &str = "https://accounts.google.com/o/oauth2/auth";
+// client_id
+// must change
+static CLIENT_ID: &str = "your_client_id";
+// client_secret
+// must change
+static CLIENT_SECRET: &str = "your_client_secret";
+// redirect_url
+static REDIRECT_URL: &str = "http://localhost/auth/callback";
+// token endpoint
+static TOKEN_ENDPOINT: &str = "https://oauth2.googleapis.com/token";
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // init log
+    tracing_subscriber::fmt::init();
+
+    // Redis connection set up
+    let redis_client = redis::Client::open(REDIS_URL).expect("Failed to open redis client");
+    let redis_conn = ConnectionManager::new(redis_client)
+        .await
+        .expect("Failed to establish redis connection");
+
+    let addr = SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), PORT);
+    let listener = tokio::net::TcpListener::bind(addr)
+        .await
+        .expect("Failed to bind tcp listener");
+
+    info!("Server is running");
+
+    // Construct Config That is warped by Arc
+    let config = Arc::new(ConfigBuilder::new()
+        .auth_endpoint(AUTH_ENDPOINT)
+        .client_id(CLIENT_ID)
+        .client_secret(CLIENT_SECRET)
+        .redirect_uri(REDIRECT_URL)
+        .token_endpoint(TOKEN_ENDPOINT)
+        .build());
+
+    // Routing services
+    // login, rootPage, protectedPage(session)...
+    let service = Router::new(config.clone(), redis_conn);
+
+    info!("Listening on {:?}", addr);
+
+    loop {
+        let (stream, _) = listener.accept().await?;
+        let io = TokioIo::new(stream);
+
+        let service = service.clone();
+        tokio::task::spawn(async move {
+            let conn = http1::Builder::new().serve_connection(io, service);
+            tokio::pin!(conn);
+
+            // If it takes more than 5 seconds, it times out
+            tokio::select! {
+                res = conn.as_mut() => match res {
+                    Ok(()) => {},
+                    Err(e) => error!("error: {:?}", e),
+                },
+                _ = tokio::time::sleep(Duration::from_secs(5)) => {
+                    conn.graceful_shutdown();
+                }
+            }
+        });
+    }
+}

--- a/examples/hyper/main.rs
+++ b/examples/hyper/main.rs
@@ -33,7 +33,6 @@ mod router;
 mod login_service;
 
 static REDIS_URL: &str = "redis://localhost:6379";
-static PORT: u16 = 80;
 // Google OpenID Connect
 // Change me according to client_secret.json that is downloaded
 // auth_endpoint
@@ -60,7 +59,7 @@ async fn main() -> anyhow::Result<()> {
         .await
         .expect("Failed to establish redis connection");
 
-    let addr = SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), PORT);
+    let addr = SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), 80);
     let listener = tokio::net::TcpListener::bind(addr)
         .await
         .expect("Failed to bind tcp listener");

--- a/examples/hyper/protected.rs
+++ b/examples/hyper/protected.rs
@@ -1,0 +1,78 @@
+use bytes::Bytes;
+use cookie::Cookie;
+use http::{
+    header::{COOKIE, LOCATION}, HeaderValue, Request, Response, StatusCode
+};
+use http_body_util::{BodyExt, Empty, Full, combinators::BoxBody};
+use hyper::body::Incoming;
+use redis::{aio::ConnectionManager, cmd};
+
+use crate::login_service::SESSION_COOKIE_KEY;
+
+pub struct ProtectedService {
+    redis_conn: ConnectionManager,
+}
+
+impl ProtectedService {
+    pub fn new(redis_conn: ConnectionManager) -> Self {
+        Self { redis_conn }
+    }
+
+    pub async fn serve(
+        &mut self,
+        req: Request<Incoming>,
+    ) -> anyhow::Result<Response<BoxBody<Bytes, std::io::Error>>> {
+        // Get Cookie Header values
+        let cookie_header_val = match req.headers().get(COOKIE) {
+            Some(v) => v,
+            None => return Ok(see_location_res("/")),
+        };
+        let cookies = Self::parse_cookies(&cookie_header_val)?;
+
+
+        // Find a Cookie with key "session"
+        let session_id = match cookies.iter().find(|c| c.name() == SESSION_COOKIE_KEY) {
+            Some(cookie) => cookie.value(),
+            None => return Ok(see_location_res("/")),
+        };
+
+        // Verify session(Redis)
+        match self.verify_session(&session_id).await? {
+            Some(v) => {
+                let txt = format!("Hi! your id is {}", v);
+                let res = Response::builder()
+                    .status(StatusCode::OK)
+                    .body(Full::new(Bytes::from(txt)).map_err(|e| match e {}).boxed())
+                    .unwrap();
+                Ok(res)
+            }
+            None => Ok(see_location_res("/")) 
+        }
+    }
+
+    fn parse_cookies(header_val: &HeaderValue) -> anyhow::Result<Vec<Cookie<'_>>> {
+        let values = header_val.to_str()?;
+
+        let cookies: Vec<Cookie<'_>> = values
+            .split(';')
+            .filter_map(|c| Cookie::parse(c.trim().to_string()).ok())
+            .collect();
+        Ok(cookies)
+    }
+
+    async fn verify_session(&mut self, session_id: &str) -> anyhow::Result<Option<String>> {
+        let session = cmd("GET")
+            .arg(session_id)
+            .query_async::<Option<String>>(&mut self.redis_conn)
+            .await?;
+        Ok(session)
+    }
+}
+
+pub fn see_location_res(url: &str) -> Response<BoxBody<Bytes, std::io::Error>> {
+    Response::builder()
+        .status(StatusCode::SEE_OTHER)
+        .header(LOCATION, url)
+        .body(Empty::new().map_err(|e| match e {}).boxed())
+        .unwrap()
+}

--- a/examples/hyper/router.rs
+++ b/examples/hyper/router.rs
@@ -1,0 +1,102 @@
+use std::{convert::Infallible, pin::Pin, sync::Arc};
+
+use bytes::Bytes;
+use http_body_util::{combinators::BoxBody, BodyExt, Empty, StreamBody};
+use hyper::{Request, Response, StatusCode, body::Incoming, service::Service};
+use redis::aio::ConnectionManager;
+use tiny_google_oidc::config::Config;
+use tokio::fs::File;
+use tokio_util::io::ReaderStream;
+use futures_util::TryStreamExt;
+
+use crate::{protected::ProtectedService, login_service::LoginService};
+
+#[derive(Clone)]
+pub struct Router {
+    config: Arc<Config>,
+    redis_conn: ConnectionManager,
+}
+
+impl Router {
+    pub fn new(config: Arc<Config>, redis_conn: ConnectionManager) -> Self {
+        Self {
+            config: config,
+            redis_conn,
+        }
+    }
+
+    pub fn config(&self) -> Arc<Config> {
+        Arc::clone(&self.config)
+    }
+
+    pub fn redis_conn(&self) -> ConnectionManager {
+        self.redis_conn.clone()
+    }
+}
+
+// Routing
+// - "/" return html file
+// - "/auth" is open id connect auth entry point 
+// - "/auth/callback" is redirect path from Google
+// - "/protected" provides information about the user who has a session
+impl Service<Request<Incoming>> for Router {
+    type Response = Response<BoxBody<Bytes, std::io::Error>>;
+    type Error = Infallible;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn call(&self, req: Request<Incoming>) -> Self::Future {
+        let redis_conn = self.redis_conn();
+        let config = self.config();
+
+        Box::pin(async move {
+            let default = Response::builder()
+                .status(StatusCode::INTERNAL_SERVER_ERROR)
+                .body(Empty::new().map_err(|e| match e {}).boxed())
+                .unwrap();
+
+            match req.uri().path().to_string().as_ref() {
+                "/" => {
+                    let file = File::open("./examples/hyper/index.html").await.unwrap();
+                    let reader_stream = ReaderStream::new(file);
+
+                    let a = StreamBody::new(reader_stream.map_ok(hyper::body::Frame::data));
+                    let box_body = BodyExt::boxed(a);
+
+                    let res = Response::builder()
+                        .status(StatusCode::OK)
+                        .body(box_body)
+                        .unwrap();
+                    Ok(res)
+                }
+                "/auth" => {
+                    let res = LoginService::new(config, redis_conn)
+                        .entry()
+                        .await
+                        .unwrap_or(default);
+                    Ok(res)
+                }
+                "/auth/callback" => {
+                    let res = LoginService::new(config, redis_conn)
+                        .callback(req)
+                        .await
+                        .unwrap_or(default);
+                    Ok(res)
+                }
+                "/protected" => {
+                    let res = ProtectedService::new(redis_conn)
+                        .serve(req)
+                        .await
+                        .unwrap_or(default);
+                    Ok(res)
+                }
+                _ => {
+                    let res = Response::builder()
+                        .status(StatusCode::NOT_FOUND)
+                        .body(Empty::new().map_err(|e| match e {}).boxed())
+                        .unwrap();
+                    Ok(res)
+                }
+            }
+        })
+    }
+}

--- a/src/code.rs
+++ b/src/code.rs
@@ -1,6 +1,6 @@
 //! This module handles the process of requesting and verifying an authorization code
 //! in the OpenID Connect authentication flow.   
-//! 
+//!
 //! It provides the following key functionalities:
 //! - Generating an authorization request URL (`CodeRequest`).
 //! - Parsing and verifying the authorization code received from Google's callback (`UnCheckedCodeResponse`).
@@ -39,7 +39,7 @@
 //! ## Handling the Callback and Verifying the Authorization Code
 //! ```rust,no_run
 //! let response = UnCheckedCodeResponse::from_url("https://example.com/callback?...").unwrap();
-//! // get stored CSRF token From DB(Redis, in memory ...) 
+//! // get stored CSRF token From DB(Redis, in memory ...)
 //! let csrf_token = store.get("csrf_token_key")?;
 //!
 //! let code = response.exchange_with_code(csrf_token).expect("CSRF token mismatch!");
@@ -192,7 +192,7 @@ impl From<String> for Code {
 #[derive(Debug, Clone)]
 pub struct CodeRequest<S>
 where
-    S: Iterator<Item = AdditionalScope>,
+    S: IntoIterator<Item = AdditionalScope>,
 {
     auth_endpoint: AuthEndPoint,
     client_id: ClientID,
@@ -206,7 +206,7 @@ where
 
 impl<S> CodeRequest<S>
 where
-    S: Iterator<Item = AdditionalScope> + Clone,
+    S: IntoIterator<Item = AdditionalScope> + Clone,
 {
     /// # **Parameters**
     ///
@@ -256,7 +256,7 @@ where
             .scope
             .as_ref()
             .map(|s| {
-                s.clone().map(|v| match v {
+                s.clone().into_iter().map(|v| match v {
                     AdditionalScope::Email => "email",
                     AdditionalScope::Profile => "profile",
                 })
@@ -458,7 +458,7 @@ mod tests {
             .redirect_uri(redirect_url)
             .build();
 
-        let scope = Some([AdditionalScope::Email, AdditionalScope::Profile].into_iter());
+        let scope = Some([AdditionalScope::Email, AdditionalScope::Profile]);
         let state = CSRFToken::new().unwrap();
         let nonce = Nonce::new();
 
@@ -497,7 +497,7 @@ mod tests {
             .redirect_uri(redirect_url)
             .build();
 
-        let scope = Some([AdditionalScope::Email].into_iter());
+        let scope = Some([AdditionalScope::Email]);
         let state = CSRFToken::new().unwrap();
         let nonce = Nonce::new();
 
@@ -574,7 +574,6 @@ mod tests {
                 AdditionalScope::Profile,
                 AdditionalScope::Email,
             ]
-            .into_iter(),
         );
         let state = CSRFToken::new().unwrap();
         let nonce = Nonce::new();

--- a/src/code.rs
+++ b/src/code.rs
@@ -69,6 +69,16 @@ use std::{
     iter::Iterator,
 };
 
+/// Indicates a value of ```access_type``` query param.  
+/// 
+/// ```Offline``` allows include [`RefreshToken`](crate::refresh_token::RefreshToken) in [`IDTokenResponse`](crate::id_token::IDTokenResponse)  
+/// ```Online``` **not** allow include [`RefreshToken`](crate::refresh_token::RefreshToken) in [`IDTokenResponse`](crate::id_token::IDTokenResponse)  
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AccessType {
+    Online,
+    Offline
+}
+
 /// Optional Scope Parameters  
 ///
 /// In an OpenID Connect authentication request, the `scope` parameter specifies the type of user information
@@ -175,7 +185,7 @@ impl From<String> for Code {
 /// let csrf_token = CSRFToken::new().unwrap();
 /// let nonce = Nonce::new().unwrap();
 ///
-/// let request = CodeRequest::new(true, &config, None, &csrf_token, &nonce);
+/// let request = CodeRequest::new(AccessType::Online, &config, None, &csrf_token, &nonce);
 /// let url = request.into_url().unwrap();
 /// println!("Auth URL: {}", url);
 /// ```
@@ -189,7 +199,7 @@ where
     response_type: String,
     scope: Option<S>,
     redirect_uri: RedirectURI,
-    access_type: bool,
+    access_type: AccessType,
     state: CSRFToken,
     nonce: Nonce,
 }
@@ -200,9 +210,9 @@ where
 {
     /// # **Parameters**
     ///
-    /// - `access_type` (`bool`):
-    ///   - `true` → Requests an **offline** access token (includes a refresh token).
-    ///   - `false` → Requests an **online** access token (no refresh token).
+    /// - `access_type` (AccessType):
+    ///   - Offline → Requests an **offline** access token (includes a refresh token).
+    ///   - Online → Requests an **online** access token (no refresh token).
     ///
     /// - `config` (`&Config`):
     ///   - Contains necessary settings such as `client_id`, `auth_endpoint`, and `redirect_uri`.
@@ -217,7 +227,7 @@ where
     /// - `nonce` (`&Nonce`):
     ///   - A **nonce value** used to mitigate replay attacks.
     pub fn new(
-        access_type: bool,
+        access_type: AccessType,
         config: &Config,
         scope: Option<S>,
         state: &CSRFToken,
@@ -237,10 +247,9 @@ where
 
     /// Constructs a URL with the required parameters for Google authentication.
     pub fn into_url(&self) -> Result<String, Error> {
-        let access_type = if self.access_type {
-            "offline"
-        } else {
-            "online"
+        let access_type = match self.access_type {
+            AccessType::Online => "online",
+            AccessType::Offline => "offline"
         };
 
         let scope = self
@@ -319,7 +328,7 @@ impl UnCheckedCodeResponse {
 mod tests {
     use std::iter::Empty;
 
-    use crate::{config::ConfigBuilder, csrf_token::CSRFToken, nonce::Nonce};
+    use crate::{code::AccessType, config::ConfigBuilder, csrf_token::CSRFToken, nonce::Nonce};
 
     use super::{AdditionalScope, CodeRequest};
 
@@ -327,8 +336,8 @@ mod tests {
 
     // ==========CodeRequest methods==========
     #[test]
-    fn test_code_req_new_some_scope() {
-        let access_type = true;
+    fn test_code_req_offline() {
+        let access_type = AccessType::Offline;
 
         let auth_endpoint = "https://auth.example.com/auth";
         let client_id = "my_client_id";
@@ -348,7 +357,43 @@ mod tests {
         let state = CSRFToken::new().unwrap();
         let nonce = Nonce::new();
 
-        let code_req = CodeRequest::new(access_type, &config, scope.clone(), &state, &nonce);
+        let code_req = CodeRequest::new(access_type.clone(), &config, scope.clone(), &state, &nonce);
+
+        assert_eq!(code_req.access_type, access_type);
+        assert_eq!(code_req.auth_endpoint.0, auth_endpoint);
+        assert_eq!(code_req.client_id.0, client_id);
+        assert_eq!(code_req.redirect_uri.0, redirect_uri);
+        assert_eq!(code_req.state, state);
+        assert_eq!(code_req.nonce, nonce);
+
+        let expected_scope: Vec<AdditionalScope> = scope.unwrap().collect();
+        let actual_scope: Vec<AdditionalScope> = code_req.scope.unwrap().collect();
+        assert_eq!(actual_scope, expected_scope);
+    }
+
+    #[test]
+    fn test_code_req_new_some_scope() {
+        let access_type = AccessType::Online;
+
+        let auth_endpoint = "https://auth.example.com/auth";
+        let client_id = "my_client_id";
+        let client_secret = "my_secret";
+        let token_endpoint = "https://token.example.com";
+        let redirect_uri = "https://redirect.example.com";
+
+        let config = ConfigBuilder::new()
+            .auth_endpoint(auth_endpoint)
+            .client_id(client_id)
+            .client_secret(client_secret)
+            .token_endpoint(token_endpoint)
+            .redirect_uri(redirect_uri)
+            .build();
+
+        let scope = Some([AdditionalScope::Email, AdditionalScope::Profile].into_iter());
+        let state = CSRFToken::new().unwrap();
+        let nonce = Nonce::new();
+
+        let code_req = CodeRequest::new(access_type.clone(), &config, scope.clone(), &state, &nonce);
 
         assert_eq!(code_req.access_type, access_type);
         assert_eq!(code_req.auth_endpoint.0, auth_endpoint);
@@ -364,7 +409,7 @@ mod tests {
 
     #[test]
     fn test_code_req_new_none_scope() {
-        let access_type = true;
+        let access_type = AccessType::Online;
 
         let auth_endpoint = "https://auth.example.com/auth";
         let client_id = "my_client_id";
@@ -384,7 +429,7 @@ mod tests {
         let state = CSRFToken::new().unwrap();
         let nonce = Nonce::new();
 
-        let code_req = CodeRequest::new(access_type, &config, scope.clone(), &state, &nonce);
+        let code_req = CodeRequest::new(access_type.clone(), &config, scope.clone(), &state, &nonce);
 
         assert_eq!(code_req.access_type, access_type);
         assert_eq!(code_req.auth_endpoint.0, auth_endpoint);
@@ -397,7 +442,7 @@ mod tests {
 
     #[test]
     fn test_code_req_into_url() {
-        let access_type = true;
+        let access_type = AccessType::Online;
 
         let auth_endpoint = "https://auth.example.com/auth";
         let client_id = "my_client_id";
@@ -426,7 +471,7 @@ mod tests {
             "code",
             client_id,
             "openid email profile",
-            "offline",
+            "online",
             redirect_url,
             state.0,
             nonce.0,
@@ -436,7 +481,7 @@ mod tests {
 
     #[test]
     fn test_code_req_into_url_scope_one() {
-        let access_type = true;
+        let access_type = AccessType::Online;
 
         let auth_endpoint = "https://auth.example.com/auth";
         let client_id = "my_client_id";
@@ -465,7 +510,7 @@ mod tests {
             "code",
             client_id,
             "openid email",
-            "offline",
+            "online",
             redirect_url,
             state.0,
             nonce.0,
@@ -475,7 +520,7 @@ mod tests {
 
     #[test]
     fn test_code_req_into_url_scope_none() {
-        let access_type = true;
+        let access_type = AccessType::Online;
 
         let auth_endpoint = "https://auth.example.com/auth";
         let client_id = "my_client_id";
@@ -500,14 +545,14 @@ mod tests {
         let url = code_req.into_url().unwrap();
         let expected_url = format!(
             "{}?response_type={}&client_id={}&scope={}&access_type={}&redirect_uri={}&state={}&nonce={}",
-            auth_endpoint, "code", client_id, "openid", "offline", redirect_url, state.0, nonce.0,
+            auth_endpoint, "code", client_id, "openid", "online", redirect_url, state.0, nonce.0,
         );
         assert_eq!(url, expected_url);
     }
 
     #[test]
     fn test_code_req_into_url_scope_duplicate() {
-        let access_type = true;
+        let access_type = AccessType::Online;
 
         let auth_endpoint = "https://auth.example.com/auth";
         let client_id = "my_client_id";
@@ -542,7 +587,7 @@ mod tests {
             "code",
             client_id,
             "openid email profile",
-            "offline",
+            "online",
             redirect_url,
             state.0,
             nonce.0,


### PR DESCRIPTION
## Changed
- added ```AccessType``` enum
- CodeRequest Take ```AccessType``` in accsess_type filed
- CodeRequest's trait bound: ```Itarator``` -> ```IntoItarator```
## New
- added hyper example