### PR TITLE
Refactor code module

### DIFF
--- a/examples/axum_server.rs
+++ b/examples/axum_server.rs
@@ -106,6 +106,8 @@ async fn start_auth(
     // Generate Nonce
     let nonce = Nonce::new();
     let scope = Some([AdditionalScope::Email, AdditionalScope::Profile]);
+    // if You'd like to set none, you need type annotation like this.
+    // let scope: Option<std::iter::Empty<AdditionalScope>> = None;
 
     // Construct CodeRequest from config, scope, csrf_token, nonce
     let req = CodeRequest::new(
@@ -219,14 +221,14 @@ fn read_env(key: &str) -> anyhow::Result<String> {
 
 #[derive(Debug, Clone)]
 struct AppState {
-    config: Config,
+    config: Arc<Config>,
     token: Arc<Mutex<HashMap<String, CSRFToken>>>,
 }
 
 impl AppState {
     fn new(config: Config) -> Self {
         Self {
-            config,
+            config: Arc::new(config),
             token: Arc::default(),
         }
     }

--- a/examples/axum_server.rs
+++ b/examples/axum_server.rs
@@ -117,9 +117,9 @@ async fn start_auth(
     );
     // Convert as URL
     let url = req
-        .into_url()
+        .try_into_url()
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    Ok((jar.add(cookie), Redirect::to(&url)))
+    Ok((jar.add(cookie), Redirect::to(&url.to_string())))
 }
 
 async fn call_back(

--- a/examples/hyper/login_service.rs
+++ b/examples/hyper/login_service.rs
@@ -66,11 +66,11 @@ impl LoginService {
             &csrf_token,
             &Nonce::new(),
         )
-        .into_url()?;
+        .try_into_url()?;
 
         let res = Response::builder()
             .status(StatusCode::SEE_OTHER)
-            .header(LOCATION, url)
+            .header(LOCATION, url.to_string())
             .header(SET_COOKIE, cookie.to_string())
             .body(Empty::new().map_err(|e| match e {}).boxed())
             .unwrap();

--- a/src/code.rs
+++ b/src/code.rs
@@ -57,6 +57,7 @@
 //! - Do not use `UnCheckedCodeResponse` directly without verification.
 use itertools::Itertools;
 use tracing::error;
+use url::Url;
 
 use crate::{
     config::{AuthEndPoint, ClientID, Config, RedirectURI},
@@ -185,7 +186,7 @@ where
     }
 
     /// Constructs a URL with the required parameters for Google authentication.
-    pub fn into_url(&self) -> Result<String, Error> {
+    pub fn try_into_url(self) -> Result<Url, Error> {
         let access_type = match self.access_type {
             AccessType::Online => "online",
             AccessType::Offline => "offline",
@@ -220,6 +221,7 @@ where
             self.state.0,
             self.nonce.0,
         );
+        let url = Url::parse(&url).map_err(|_| Error::URL)?;
         Ok(url)
     }
 }
@@ -320,6 +322,8 @@ pub enum AdditionalScope {
 #[cfg(test)]
 mod tests {
     use std::iter::Empty;
+
+    use url::Url;
 
     use crate::{code::AccessType, config::ConfigBuilder, csrf_token::CSRFToken, nonce::Nonce};
 
@@ -457,7 +461,7 @@ mod tests {
 
         let code_req = CodeRequest::new(access_type, &config, scope.clone(), &state, &nonce);
 
-        let url = code_req.into_url().unwrap();
+        let url = code_req.try_into_url().unwrap();
         let expected_url = format!(
             "{}?response_type={}&client_id={}&scope={}&access_type={}&redirect_uri={}&state={}&nonce={}",
             auth_endpoint,
@@ -469,7 +473,7 @@ mod tests {
             state.0,
             nonce.0,
         );
-        assert_eq!(url, expected_url);
+        assert_eq!(url, Url::parse(&expected_url).unwrap());
     }
 
     #[test]
@@ -496,7 +500,7 @@ mod tests {
 
         let code_req = CodeRequest::new(access_type, &config, scope.clone(), &state, &nonce);
 
-        let url = code_req.into_url().unwrap();
+        let url = code_req.try_into_url().unwrap();
         let expected_url = format!(
             "{}?response_type={}&client_id={}&scope={}&access_type={}&redirect_uri={}&state={}&nonce={}",
             auth_endpoint,
@@ -508,7 +512,7 @@ mod tests {
             state.0,
             nonce.0,
         );
-        assert_eq!(url, expected_url);
+        assert_eq!(url, Url::parse(&expected_url).unwrap());
     }
 
     #[test]
@@ -535,12 +539,12 @@ mod tests {
 
         let code_req = CodeRequest::new(access_type, &config, scope.clone(), &state, &nonce);
 
-        let url = code_req.into_url().unwrap();
+        let url = code_req.try_into_url().unwrap();
         let expected_url = format!(
             "{}?response_type={}&client_id={}&scope={}&access_type={}&redirect_uri={}&state={}&nonce={}",
             auth_endpoint, "code", client_id, "openid", "online", redirect_url, state.0, nonce.0,
         );
-        assert_eq!(url, expected_url);
+        assert_eq!(url, Url::parse(&expected_url).unwrap());
     }
 
     #[test]
@@ -570,7 +574,7 @@ mod tests {
         let nonce = Nonce::new();
 
         let code_req = CodeRequest::new(access_type, &config, scope.clone(), &state, &nonce);
-        let url = code_req.into_url().unwrap();
+        let url = code_req.try_into_url().unwrap();
         let expected_url = format!(
             "{}?response_type={}&client_id={}&scope={}&access_type={}&redirect_uri={}&state={}&nonce={}",
             auth_endpoint,
@@ -582,6 +586,6 @@ mod tests {
             state.0,
             nonce.0,
         );
-        assert_eq!(url, expected_url);
+        assert_eq!(url, Url::parse(&expected_url).unwrap());
     }
 }

--- a/src/code.rs
+++ b/src/code.rs
@@ -113,12 +113,6 @@ impl Code {
     }
 }
 
-impl From<String> for Code {
-    fn from(value: String) -> Self {
-        Self(value)
-    }
-}
-
 /// Generates a URL to initiate the authorization request.
 /// # Example
 /// ```rust,no_run
@@ -254,7 +248,7 @@ impl UnCheckedCodeResponse {
         let params: HashMap<_, _> = url.query_pairs().map(|v| (v.0, v.1)).collect();
         Ok(Self {
             state: params.get("state").ok_or(Error::URL)?.to_string().into(),
-            code: params.get("code").ok_or(Error::URL)?.to_string().into(),
+            code: Code(params.get("code").ok_or(Error::URL)?.to_string()),
         })
     }
 

--- a/src/code.rs
+++ b/src/code.rs
@@ -69,61 +69,6 @@ use std::{
     iter::Iterator,
 };
 
-/// Indicates a value of ```access_type``` query param.  
-///
-/// ```Offline``` allows include [`RefreshToken`](crate::refresh_token::RefreshToken) in [`IDTokenResponse`](crate::id_token::IDTokenResponse)  
-/// ```Online``` **not** allow include [`RefreshToken`](crate::refresh_token::RefreshToken) in [`IDTokenResponse`](crate::id_token::IDTokenResponse)  
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum AccessType {
-    Online,
-    Offline,
-}
-
-/// Optional Scope Parameters  
-///
-/// In an OpenID Connect authentication request, the `scope` parameter specifies the type of user information
-/// that should be included in the ID token. By default, the `openid` scope is required for authentication.
-/// This enum allows adding **optional** scopes, such as `email` or `profile`, to the request.
-///
-/// # Purpose
-/// `AdditionalScope` is used to extend the default `scope` parameter when creating a `CodeRequest`.
-/// It enables applications to request additional user information from Google.
-///
-/// # Variants
-///
-/// ## `Email`
-/// - Requests the user's **email address** and **email verification status**.
-/// - This is useful if the application needs to identify the user by their email address.
-///
-/// ## `Profile`
-/// - Requests the user's **name, profile picture URL, and other basic profile information**.
-/// - This is useful for displaying user details in the application.
-///
-/// # Usage
-/// To include `email` or `profile` in the scope, add `AdditionalScope::Email` or `AdditionalScope::Profile`
-/// when creating a `CodeRequest`.
-///
-/// # Example
-/// ```rust,no_run
-/// use crate::code::AdditionalScope;
-///
-/// let additional_scopes = Some([AdditionalScope::Email, AdditionalScope::Profile].into_iter());
-/// let request = CodeRequest::new(true, &config, additional_scopes, &csrf_token, &nonce);
-/// let url = request.into_url().unwrap();
-/// println!("Authorization URL: {}", url);
-/// ```
-///
-/// If **no additional scopes** are specified, the request will **only include `openid`**, which is required for authentication.
-///
-/// # Notes
-/// - Adding `email` or `profile` scopes allows the application to access more detailed user information.
-/// - Ensure that the requested scopes align with the application's privacy policy and user consent.
-#[derive(Debug, Clone, PartialEq)]
-pub enum AdditionalScope {
-    Email,
-    Profile,
-}
-
 /// Represents the value of the `code` query parameter sent by Google during the OpenID Connect flow.  
 /// This structure ensures that the `code` can only be obtained after validating the associated `CSRFToken`.
 ///
@@ -323,7 +268,61 @@ impl UnCheckedCodeResponse {
     }
 }
 
-// ==========Tests==========
+/// Indicates a value of ```access_type``` query param.  
+///
+/// ```Offline``` allows include [`RefreshToken`](crate::refresh_token::RefreshToken) in [`IDTokenResponse`](crate::id_token::IDTokenResponse)  
+/// ```Online``` **not** allow include [`RefreshToken`](crate::refresh_token::RefreshToken) in [`IDTokenResponse`](crate::id_token::IDTokenResponse)  
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AccessType {
+    Online,
+    Offline,
+}
+
+/// Optional Scope Parameters  
+///
+/// In an OpenID Connect authentication request, the `scope` parameter specifies the type of user information
+/// that should be included in the ID token. By default, the `openid` scope is required for authentication.
+/// This enum allows adding **optional** scopes, such as `email` or `profile`, to the request.
+///
+/// # Purpose
+/// `AdditionalScope` is used to extend the default `scope` parameter when creating a `CodeRequest`.
+/// It enables applications to request additional user information from Google.
+///
+/// # Variants
+///
+/// ## `Email`
+/// - Requests the user's **email address** and **email verification status**.
+/// - This is useful if the application needs to identify the user by their email address.
+///
+/// ## `Profile`
+/// - Requests the user's **name, profile picture URL, and other basic profile information**.
+/// - This is useful for displaying user details in the application.
+///
+/// # Usage
+/// To include `email` or `profile` in the scope, add `AdditionalScope::Email` or `AdditionalScope::Profile`
+/// when creating a `CodeRequest`.
+///
+/// # Example
+/// ```rust,no_run
+/// use crate::code::AdditionalScope;
+///
+/// let additional_scopes = Some([AdditionalScope::Email, AdditionalScope::Profile].into_iter());
+/// let request = CodeRequest::new(true, &config, additional_scopes, &csrf_token, &nonce);
+/// let url = request.into_url().unwrap();
+/// println!("Authorization URL: {}", url);
+/// ```
+///
+/// If **no additional scopes** are specified, the request will **only include `openid`**, which is required for authentication.
+///
+/// # Notes
+/// - Adding `email` or `profile` scopes allows the application to access more detailed user information.
+/// - Ensure that the requested scopes align with the application's privacy policy and user consent.
+#[derive(Debug, Clone, PartialEq)]
+pub enum AdditionalScope {
+    Email,
+    Profile,
+}
+
 #[cfg(test)]
 mod tests {
     use std::iter::Empty;
@@ -332,9 +331,6 @@ mod tests {
 
     use super::{AdditionalScope, CodeRequest};
 
-    // ==========Code methods==========
-
-    // ==========CodeRequest methods==========
     #[test]
     fn test_code_req_offline() {
         let access_type = AccessType::Offline;

--- a/src/code.rs
+++ b/src/code.rs
@@ -32,7 +32,7 @@
 //! let scope = Some([AdditionalScope::Email, AdditionalScope::Profile].into_iter());
 //!
 //! let request = CodeRequest::new(true, &config, scope, &csrf_token, &nonce);
-//! let url = request.into_url().unwrap();
+//! let url = request.try_into_url().unwrap();
 //! println!("Auth URL: {}", url);
 //! ```
 //!
@@ -90,7 +90,6 @@ use std::{
 /// let csrf_token = store.get("csrf_token_key")?;
 ///
 /// let code = response.exchange_with_code(csrf_token).expect("CSRF token mismatch!");
-/// println!("Verified Code: {:?}", code);
 /// ```
 ///
 /// # Notes
@@ -123,28 +122,29 @@ impl Code {
 ///     .build();
 ///
 /// let csrf_token = CSRFToken::new().unwrap();
-/// let nonce = Nonce::new().unwrap();
+/// let nonce = Nonce::new();
+/// let scope: Option<std::iter::Empty<AdditionalScope>> = None;
 ///
-/// let request = CodeRequest::new(AccessType::Online, &config, None, &csrf_token, &nonce);
-/// let url = request.into_url().unwrap();
+/// let request = CodeRequest::new(AccessType::Online, &config, scope, &csrf_token, &nonce);
+/// let url = request.try_into_url().unwrap();
 /// println!("Auth URL: {}", url);
 /// ```
 #[derive(Debug, Clone)]
-pub struct CodeRequest<S>
+pub struct CodeRequest<'a, S>
 where
     S: IntoIterator<Item = AdditionalScope>,
 {
-    auth_endpoint: AuthEndPoint,
-    client_id: ClientID,
-    response_type: String,
+    auth_endpoint: &'a AuthEndPoint,
+    client_id: &'a ClientID,
+    response_type: &'a str,
     scope: Option<S>,
-    redirect_uri: RedirectURI,
+    redirect_uri: &'a RedirectURI,
     access_type: AccessType,
-    state: CSRFToken,
-    nonce: Nonce,
+    state: &'a CSRFToken,
+    nonce: &'a Nonce,
 }
 
-impl<S> CodeRequest<S>
+impl<'a, S> CodeRequest<'a, S>
 where
     S: IntoIterator<Item = AdditionalScope> + Clone,
 {
@@ -168,20 +168,20 @@ where
     ///   - A **nonce value** used to mitigate replay attacks.
     pub fn new(
         access_type: AccessType,
-        config: &Config,
+        config: &'a Config,
         scope: Option<S>,
-        state: &CSRFToken,
-        nonce: &Nonce,
+        state: &'a CSRFToken,
+        nonce: &'a Nonce,
     ) -> Self {
         Self {
-            auth_endpoint: config.auth_endpoint.to_owned(),
-            client_id: config.client_id.to_owned(),
-            response_type: "code".to_string(),
+            auth_endpoint: &config.auth_endpoint,
+            client_id: &config.client_id,
+            response_type: "code",
             scope,
-            redirect_uri: config.redirect_uri.to_owned(),
+            redirect_uri: &config.redirect_uri,
             access_type,
-            state: state.to_owned(),
-            nonce: nonce.to_owned(),
+            state,
+            nonce,
         }
     }
 
@@ -358,8 +358,8 @@ mod tests {
         assert_eq!(code_req.auth_endpoint.0, auth_endpoint);
         assert_eq!(code_req.client_id.0, client_id);
         assert_eq!(code_req.redirect_uri.0, redirect_uri);
-        assert_eq!(code_req.state, state);
-        assert_eq!(code_req.nonce, nonce);
+        assert_eq!(*code_req.state, state);
+        assert_eq!(*code_req.nonce, nonce);
 
         let expected_scope: Vec<AdditionalScope> = scope.unwrap().collect();
         let actual_scope: Vec<AdditionalScope> = code_req.scope.unwrap().collect();
@@ -395,8 +395,8 @@ mod tests {
         assert_eq!(code_req.auth_endpoint.0, auth_endpoint);
         assert_eq!(code_req.client_id.0, client_id);
         assert_eq!(code_req.redirect_uri.0, redirect_uri);
-        assert_eq!(code_req.state, state);
-        assert_eq!(code_req.nonce, nonce);
+        assert_eq!(*code_req.state, state);
+        assert_eq!(*code_req.nonce, nonce);
 
         let expected_scope: Vec<AdditionalScope> = scope.unwrap().collect();
         let actual_scope: Vec<AdditionalScope> = code_req.scope.unwrap().collect();
@@ -432,8 +432,8 @@ mod tests {
         assert_eq!(code_req.auth_endpoint.0, auth_endpoint);
         assert_eq!(code_req.client_id.0, client_id);
         assert_eq!(code_req.redirect_uri.0, redirect_uri);
-        assert_eq!(code_req.state, state);
-        assert_eq!(code_req.nonce, nonce);
+        assert_eq!(*code_req.state, state);
+        assert_eq!(*code_req.nonce, nonce);
         assert!(code_req.scope.is_none())
     }
 


### PR DESCRIPTION
## Changed
-  Type of ```Code``` struct fileds to have reference.
- ```Code:Request::into_url``` name to ```try_into_url```
- Argument type of ```Code:Request::try_into_url``` from ```&self``` to ```self```
- Return type of ```Code:Request::try_into_url``` method from ```Result<String, E>``` to ```Result<Url, E>```
## Removed
- Implementation of ```From<String> for Code