### PR TITLE
refactor: improve the way of specifying additional scopes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,12 +254,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
-name = "either"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -703,15 +697,6 @@ name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
-
-[[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itoa"
@@ -1603,7 +1588,6 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
- "itertools",
  "rand 0.9.0",
  "redis",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ edition = "2024"
 [dependencies]
 base64 = "0.22"
 http = "1"
-itertools = "0.14"
 rand = "0.9"
 reqwest = { version = "0.12", features = ["json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }

--- a/examples/axum_server.rs
+++ b/examples/axum_server.rs
@@ -104,7 +104,7 @@ async fn start_auth(
     }
     // Generate Nonce
     let nonce = Nonce::new();
-    let scope = Some([AdditionalScope::Email, AdditionalScope::Profile]);
+    let scope = AdditionalScope::Both;
     // if You'd like to set none, you need type annotation like this.
     // let scope: Option<std::iter::Empty<AdditionalScope>> = None;
 

--- a/examples/axum_server.rs
+++ b/examples/axum_server.rs
@@ -105,8 +105,6 @@ async fn start_auth(
     // Generate Nonce
     let nonce = Nonce::new();
     let scope = AdditionalScope::Both;
-    // if You'd like to set none, you need type annotation like this.
-    // let scope: Option<std::iter::Empty<AdditionalScope>> = None;
 
     // Construct CodeRequest from config, scope, csrf_token, nonce
     let req = CodeRequest::new(

--- a/examples/hyper/login_service.rs
+++ b/examples/hyper/login_service.rs
@@ -48,7 +48,7 @@ impl LoginService {
 
         // Specify the OpenId Connect scope
         // Specify that the email and username should be included in the ID token
-        let scope = Some([AdditionalScope::Email, AdditionalScope::Profile]);
+        let scope = AdditionalScope::Both;
 
         // Store CSRF token in Redis
         let _ = cmd("SET")

--- a/src/code.rs
+++ b/src/code.rs
@@ -29,7 +29,7 @@
 //!
 //! let csrf_token = CSRFToken::new().unwrap();
 //! let nonce = Nonce::new();
-//! let scope = Some([AdditionalScope::Email, AdditionalScope::Profile].into_iter());
+//! let scope = AdditionalScope::Email;
 //!
 //! let request = CodeRequest::new(true, &config, scope, &csrf_token, &nonce);
 //! let url = request.try_into_url().unwrap();
@@ -55,7 +55,6 @@
 //! # Notes
 //! - Always validate the CSRF token to ensure the integrity of the authentication flow.
 //! - Do not use `UnCheckedCodeResponse` directly without verification.
-use itertools::Itertools;
 use tracing::error;
 use url::Url;
 
@@ -65,10 +64,7 @@ use crate::{
     error::Error,
     nonce::Nonce,
 };
-use std::{
-    collections::{HashMap, HashSet},
-    iter::Iterator,
-};
+use std::{collections::HashMap, iter::Iterator};
 
 /// Represents the value of the `code` query parameter sent by Google during the OpenID Connect flow.  
 /// This structure ensures that the `code` can only be obtained after validating the associated `CSRFToken`.
@@ -123,53 +119,47 @@ impl Code {
 ///
 /// let csrf_token = CSRFToken::new().unwrap();
 /// let nonce = Nonce::new();
-/// let scope: Option<std::iter::Empty<AdditionalScope>> = None;
+/// let scope = AdditionalScope::Email;
 ///
 /// let request = CodeRequest::new(AccessType::Online, &config, scope, &csrf_token, &nonce);
 /// let url = request.try_into_url().unwrap();
 /// println!("Auth URL: {}", url);
 /// ```
 #[derive(Debug, Clone)]
-pub struct CodeRequest<'a, S>
-where
-    S: IntoIterator<Item = AdditionalScope>,
-{
+pub struct CodeRequest<'a> {
     auth_endpoint: &'a AuthEndPoint,
     client_id: &'a ClientID,
     response_type: &'a str,
-    scope: Option<S>,
+    scope: AdditionalScope,
     redirect_uri: &'a RedirectURI,
     access_type: AccessType,
     state: &'a CSRFToken,
     nonce: &'a Nonce,
 }
 
-impl<'a, S> CodeRequest<'a, S>
-where
-    S: IntoIterator<Item = AdditionalScope> + Clone,
-{
+impl<'a> CodeRequest<'a> {
     /// # **Parameters**
     ///
-    /// - `access_type` (AccessType):
+    /// - `access_type`:
     ///   - Offline → Requests an **offline** access token (includes a refresh token).
     ///   - Online → Requests an **online** access token (no refresh token).
     ///
-    /// - `config` (`&Config`):
+    /// - `config`:
     ///   - Contains necessary settings such as `client_id`, `auth_endpoint`, and `redirect_uri`.
     ///
-    /// - `scope` (`Option<S>` where `S: Iterator<Item = AdditionalScope>`):
+    /// - `scope`:
     ///   - Specifies additional scopes (`email`, `profile`) in addition to the required `openid` scope.
     ///   - If `None`, only `openid` will be requested.
     ///
-    /// - `state` (`&CSRFToken`):
+    /// - `state`:
     ///   - A **CSRF protection token** to prevent cross-site request forgery attacks.
     ///
-    /// - `nonce` (`&Nonce`):
+    /// - `nonce`:
     ///   - A **nonce value** used to mitigate replay attacks.
     pub fn new(
         access_type: AccessType,
         config: &'a Config,
-        scope: Option<S>,
+        scope: AdditionalScope,
         state: &'a CSRFToken,
         nonce: &'a Nonce,
     ) -> Self {
@@ -192,22 +182,11 @@ where
             AccessType::Offline => "offline",
         };
 
-        let scope = self
-            .scope
-            .as_ref()
-            .map(|s| {
-                s.clone().into_iter().map(|v| match v {
-                    AdditionalScope::Email => "email",
-                    AdditionalScope::Profile => "profile",
-                })
-            })
-            .map(|v| v.collect::<HashSet<_>>().iter().sorted().join(" "));
-
-        let scope = if let Some(mut v) = scope {
-            v.insert_str(0, "openid ");
-            v
-        } else {
-            "openid".to_string()
+        let scope = match self.scope {
+            AdditionalScope::Email => "openid email",
+            AdditionalScope::Profile => "openid profile",
+            AdditionalScope::Both => "openid email profile",
+            AdditionalScope::None => "openid",
         };
 
         let url = format!(
@@ -278,7 +257,7 @@ pub enum AccessType {
 ///
 /// In an OpenID Connect authentication request, the `scope` parameter specifies the type of user information
 /// that should be included in the ID token. By default, the `openid` scope is required for authentication.
-/// This enum allows adding **optional** scopes, such as `email` or `profile`, to the request.
+/// This enum allows adding **optional** scopes, such as `email`, `profile`, or both, to the request.
 ///
 /// # Purpose
 /// `AdditionalScope` is used to extend the default `scope` parameter when creating a `CodeRequest`.
@@ -294,15 +273,17 @@ pub enum AccessType {
 /// - Requests the user's **name, profile picture URL, and other basic profile information**.
 /// - This is useful for displaying user details in the application.
 ///
-/// # Usage
-/// To include `email` or `profile` in the scope, add `AdditionalScope::Email` or `AdditionalScope::Profile`
-/// when creating a `CodeRequest`.
+/// ## Both
+/// This allows you to add both `Email` and `Profile` scopes  
+///
+/// ## None
+/// No additional scopes are added  
 ///
 /// # Example
 /// ```rust,no_run
 /// use crate::code::AdditionalScope;
 ///
-/// let additional_scopes = Some([AdditionalScope::Email, AdditionalScope::Profile].into_iter());
+/// let additional_scopes = AdditionalScope::Both;
 /// let request = CodeRequest::new(true, &config, additional_scopes, &csrf_token, &nonce);
 /// let url = request.into_url().unwrap();
 /// println!("Authorization URL: {}", url);
@@ -317,12 +298,12 @@ pub enum AccessType {
 pub enum AdditionalScope {
     Email,
     Profile,
+    Both,
+    None,
 }
 
 #[cfg(test)]
 mod tests {
-    use std::iter::Empty;
-
     use url::Url;
 
     use crate::{code::AccessType, config::ConfigBuilder, csrf_token::CSRFToken, nonce::Nonce};
@@ -347,7 +328,7 @@ mod tests {
             .redirect_uri(redirect_uri)
             .build();
 
-        let scope = Some([AdditionalScope::Email, AdditionalScope::Profile].into_iter());
+        let scope = AdditionalScope::Both;
         let state = CSRFToken::new().unwrap();
         let nonce = Nonce::new();
 
@@ -360,10 +341,7 @@ mod tests {
         assert_eq!(code_req.redirect_uri.0, redirect_uri);
         assert_eq!(*code_req.state, state);
         assert_eq!(*code_req.nonce, nonce);
-
-        let expected_scope: Vec<AdditionalScope> = scope.unwrap().collect();
-        let actual_scope: Vec<AdditionalScope> = code_req.scope.unwrap().collect();
-        assert_eq!(actual_scope, expected_scope);
+        assert_eq!(code_req.scope, scope);
     }
 
     #[test]
@@ -384,7 +362,7 @@ mod tests {
             .redirect_uri(redirect_uri)
             .build();
 
-        let scope = Some([AdditionalScope::Email, AdditionalScope::Profile].into_iter());
+        let scope = AdditionalScope::Both;
         let state = CSRFToken::new().unwrap();
         let nonce = Nonce::new();
 
@@ -397,10 +375,7 @@ mod tests {
         assert_eq!(code_req.redirect_uri.0, redirect_uri);
         assert_eq!(*code_req.state, state);
         assert_eq!(*code_req.nonce, nonce);
-
-        let expected_scope: Vec<AdditionalScope> = scope.unwrap().collect();
-        let actual_scope: Vec<AdditionalScope> = code_req.scope.unwrap().collect();
-        assert_eq!(actual_scope, expected_scope);
+        assert_eq!(code_req.scope, scope);
     }
 
     #[test]
@@ -421,7 +396,7 @@ mod tests {
             .redirect_uri(redirect_uri)
             .build();
 
-        let scope: Option<Empty<AdditionalScope>> = None;
+        let scope = AdditionalScope::None;
         let state = CSRFToken::new().unwrap();
         let nonce = Nonce::new();
 
@@ -434,7 +409,7 @@ mod tests {
         assert_eq!(code_req.redirect_uri.0, redirect_uri);
         assert_eq!(*code_req.state, state);
         assert_eq!(*code_req.nonce, nonce);
-        assert!(code_req.scope.is_none())
+        assert_eq!(code_req.scope, scope);
     }
 
     #[test]
@@ -455,11 +430,11 @@ mod tests {
             .redirect_uri(redirect_url)
             .build();
 
-        let scope = Some([AdditionalScope::Email, AdditionalScope::Profile]);
+        let scope = AdditionalScope::Both;
         let state = CSRFToken::new().unwrap();
         let nonce = Nonce::new();
 
-        let code_req = CodeRequest::new(access_type, &config, scope.clone(), &state, &nonce);
+        let code_req = CodeRequest::new(access_type, &config, scope, &state, &nonce);
 
         let url = code_req.try_into_url().unwrap();
         let expected_url = format!(
@@ -494,11 +469,11 @@ mod tests {
             .redirect_uri(redirect_url)
             .build();
 
-        let scope = Some([AdditionalScope::Email]);
+        let scope = AdditionalScope::Email;
         let state = CSRFToken::new().unwrap();
         let nonce = Nonce::new();
 
-        let code_req = CodeRequest::new(access_type, &config, scope.clone(), &state, &nonce);
+        let code_req = CodeRequest::new(access_type, &config, scope, &state, &nonce);
 
         let url = code_req.try_into_url().unwrap();
         let expected_url = format!(
@@ -533,58 +508,16 @@ mod tests {
             .redirect_uri(redirect_url)
             .build();
 
-        let scope: Option<Empty<AdditionalScope>> = None;
+        let scope = AdditionalScope::None;
         let state = CSRFToken::new().unwrap();
         let nonce = Nonce::new();
 
-        let code_req = CodeRequest::new(access_type, &config, scope.clone(), &state, &nonce);
+        let code_req = CodeRequest::new(access_type, &config, scope, &state, &nonce);
 
         let url = code_req.try_into_url().unwrap();
         let expected_url = format!(
             "{}?response_type={}&client_id={}&scope={}&access_type={}&redirect_uri={}&state={}&nonce={}",
             auth_endpoint, "code", client_id, "openid", "online", redirect_url, state.0, nonce.0,
-        );
-        assert_eq!(url, Url::parse(&expected_url).unwrap());
-    }
-
-    #[test]
-    fn test_code_req_into_url_scope_duplicate() {
-        let access_type = AccessType::Online;
-
-        let auth_endpoint = "https://auth.example.com/auth";
-        let client_id = "my_client_id";
-        let client_secret = "my_secret";
-        let token_endpoint = "https://token.example.com";
-        let redirect_url = "https://redirect.example.com";
-
-        let config = ConfigBuilder::new()
-            .auth_endpoint(auth_endpoint)
-            .client_id(client_id)
-            .client_secret(client_secret)
-            .token_endpoint(token_endpoint)
-            .redirect_uri(redirect_url)
-            .build();
-
-        let scope = Some([
-            AdditionalScope::Email,
-            AdditionalScope::Profile,
-            AdditionalScope::Email,
-        ]);
-        let state = CSRFToken::new().unwrap();
-        let nonce = Nonce::new();
-
-        let code_req = CodeRequest::new(access_type, &config, scope.clone(), &state, &nonce);
-        let url = code_req.try_into_url().unwrap();
-        let expected_url = format!(
-            "{}?response_type={}&client_id={}&scope={}&access_type={}&redirect_uri={}&state={}&nonce={}",
-            auth_endpoint,
-            "code",
-            client_id,
-            "openid email profile",
-            "online",
-            redirect_url,
-            state.0,
-            nonce.0,
         );
         assert_eq!(url, Url::parse(&expected_url).unwrap());
     }


### PR DESCRIPTION
## OverView
This PR introduces **breaking changes**.  
It changes the way additional scopes are specified, making it easier to use `AdditionalScope`.  
## Problem Before
In previous versions, the define of CodeRequest was as follows: 
```rust
#[derive(Debug, Clone)]
pub struct CodeRequest<'a, S>
where
    S: IntoIterator<Item = AdditionalScope>,
{
    auth_endpoint: &'a AuthEndPoint,
    client_id: &'a ClientID,
    response_type: &'a str,
    scope: Option<S>,
    redirect_uri: &'a RedirectURI,
    access_type: AccessType,
    state: &'a CSRFToken,
    nonce: &'a Nonce,
}
``` 

This made difficult to specify AdditionalScope and construct ```CodeRequest```,  especially ```None``` case, becase explicit type annotation was required.  

```rust
// type annotaiont needed
let scope: Option<std::iter::Empty<AdditionalScope>> = None;

let req = CodeRequest::new(
    AccessType::Offline,
    &app_state.config,
    scope,
    &state,
    &nonce
);
```

## Solution
Remove ```IntoIterator``` trait bound and adds new AdditionalScope variants: ```Both``` and ```None```.  
- ```Both``` mean both ```Email``` and ```Profile``` scopes are added
- ```None``` mean no additional scope are added

```rust
#[derive(Debug, Clone)]
pub struct CodeRequest {
    auth_endpoint: &'a AuthEndPoint,
    client_id: &'a ClientID,
    response_type: &'a str,
    // change from Option<S> to AdditionalScope
    scope: AdditionalScope,
    redirect_uri: &'a RedirectURI,
    access_type: AccessType,
    state: &'a CSRFToken,
    nonce: &'a Nonce,
}

impl CodeRequest {
    pub fn new(
        access_type: AccessType,
        config: &'a Config,
        scope: AdditionalScope,
        state: &'a CSRFToken,
        nonce: &'a Nonce,
    ) -> Self {
            // ...
    }
}

#[derive(Debug, Clone, PartialEq)]
pub enum AdditionalScope {
    Email,
    Profile,
    Both,
    None,
}
```

This allows you to specify the ```None``` case,  without needing type annotations.  

```rust
let req = CodeRequest::new(
    AccessType::Offline,
    &app_state.config,
    AdditionalScope::None,
    &state,
    &nonce
);
```