### PR TITLE
Rename a misspelled struct: `IDTokenRow`

### DIFF
--- a/examples/axum_server.rs
+++ b/examples/axum_server.rs
@@ -161,9 +161,9 @@ async fn call_back(
     let refresh_token = res.access_token();
     println!("{:?}", refresh_token);
     // Get IDToken that Base64URL encoded
-    let id_token_row = res.id_token();
+    let id_token_raw = res.id_token();
     // Decode and Get IDToken that deserialized
-    let id_token = IDToken::from_id_token_row(id_token_row).unwrap();
+    let id_token = IDToken::from_id_token_raw(id_token_raw).unwrap();
     Ok((StatusCode::OK, Json(id_token)))
 }
 

--- a/examples/hyper/login_service.rs
+++ b/examples/hyper/login_service.rs
@@ -113,7 +113,7 @@ impl LoginService {
         let _refresh_token = id_token_res.refresh_token();
 
         // Get IDToken(Decode)
-        let id_token = IDToken::from_id_token_row(id_token_res.id_token())?;
+        let id_token = IDToken::from_id_token_raw(id_token_res.id_token())?;
 
         // Create SessionID
         let session_id = Uuid::new_v4().to_string();

--- a/src/id_token.rs
+++ b/src/id_token.rs
@@ -5,7 +5,7 @@
 //! IDTokenResponse: A data structure for parsing the response from the token endpoint.
 //! IDToken: A data structure representing the decoded payload of an ID token.
 //! AccessToken: A structure representing an access token used to call Google APIs.
-//! IDTokenRow: A structure representing an encoded ID token before decoding.
+//! IDTokenRaw: A structure representing an encoded ID token before decoding.
 
 use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD};
 use serde::{Deserialize, Serialize};
@@ -53,9 +53,9 @@ pub struct IDToken {
 }
 
 impl IDToken {
-    /// Construct IDToken from [`IDTokenRow`] .   
-    /// Decodes an IDTokenRow (encoded ID token) into an IDToken.
-    pub fn from_id_token_row(id_token: &IDTokenRow) -> Result<Self, Error> {
+    /// Construct IDToken from [`IDTokenRaw`] .   
+    /// Decodes an IDTokenRaw (encoded ID token) into an IDToken.
+    pub fn from_id_token_raw(id_token: &IDTokenRaw) -> Result<Self, Error> {
         let split: Vec<_> = id_token.0.split(".").collect();
         if split.len() != 3 {
             return Err(Error::Decode);
@@ -129,7 +129,7 @@ impl<'a> IDTokenRequest<'a> {
 pub struct IDTokenResponse {
     access_token: AccessToken,
     expires_in: u32,
-    id_token: IDTokenRow,
+    id_token: IDTokenRaw,
     scope: String,
     token_type: String,
     refresh_token: Option<RefreshToken>,
@@ -144,7 +144,7 @@ impl IDTokenResponse {
         self.expires_in
     }
 
-    pub fn id_token(&self) -> &IDTokenRow {
+    pub fn id_token(&self) -> &IDTokenRaw {
         &self.id_token
     }
 
@@ -175,7 +175,7 @@ impl AccessToken {
 
 /// Represents an encoded ID token, which must be decoded before use.
 #[derive(Debug, Clone, PartialEq, Deserialize)]
-pub struct IDTokenRow(String);
+pub struct IDTokenRaw(String);
 
 /// A function that sends an HTTP request to Google's authentication server to obtain an IDToken.  
 ///

--- a/src/id_token.rs
+++ b/src/id_token.rs
@@ -228,7 +228,7 @@ mod tests {
         code::Code,
         config::ConfigBuilder,
         error::Error,
-        id_token::{AccessToken, IDToken, IDTokenRequest, IDTokenResponse, IDTokenRow},
+        id_token::{AccessToken, IDToken, IDTokenRaw, IDTokenRequest, IDTokenResponse},
         refresh_token::RefreshToken,
     };
 
@@ -258,29 +258,29 @@ mod tests {
         }"#;
         let encoded = BASE64_URL_SAFE_NO_PAD.encode(id_token_json);
 
-        let mut token_row = "header.".to_string();
-        token_row.push_str(&encoded);
-        token_row.push_str(".signature");
-        let id_token_row = IDTokenRow(token_row);
+        let mut token_raw = "header.".to_string();
+        token_raw.push_str(&encoded);
+        token_raw.push_str(".signature");
+        let id_token_raw = IDTokenRaw(token_raw);
 
-        let decoded = IDToken::from_id_token_row(&id_token_row);
+        let decoded = IDToken::from_id_token_raw(&id_token_raw);
         assert!(decoded.is_ok());
     }
 
     #[test]
     fn test_id_token_decode_invalid_base64() {
-        let id_token_row = IDTokenRow("invalid_base64".to_string());
+        let id_token_raw = IDTokenRaw("invalid_base64".to_string());
 
-        let decoded = IDToken::from_id_token_row(&id_token_row);
+        let decoded = IDToken::from_id_token_raw(&id_token_raw);
         assert!(matches!(decoded, Err(Error::Decode)));
     }
 
     #[test]
     fn test_id_token_decode_invalid_json() {
         let invalid_json = BASE64_URL_SAFE_NO_PAD.encode("not a valid json");
-        let id_token_row = IDTokenRow(invalid_json);
+        let id_token_raw = IDTokenRaw(invalid_json);
 
-        let decoded = IDToken::from_id_token_row(&id_token_row);
+        let decoded = IDToken::from_id_token_raw(&id_token_raw);
         assert!(matches!(decoded, Err(Error::Decode)));
     }
 
@@ -306,13 +306,13 @@ mod tests {
     #[test]
     fn test_id_token_response_getters() {
         let access_token = AccessToken("access_token_value".to_string());
-        let id_token_row = IDTokenRow("id_token_value".to_string());
+        let id_token_raw = IDTokenRaw("id_token_value".to_string());
         let refresh_token = Some(RefreshToken("refresh_token_value".to_string()));
 
         let response = IDTokenResponse {
             access_token: access_token.clone(),
             expires_in: 3600,
-            id_token: id_token_row.clone(),
+            id_token: id_token_raw.clone(),
             scope: "openid email".to_string(),
             token_type: "Bearer".to_string(),
             refresh_token: refresh_token.clone(),
@@ -320,7 +320,7 @@ mod tests {
 
         assert_eq!(response.access_token(), &access_token);
         assert_eq!(response.expires_in(), 3600);
-        assert_eq!(response.id_token(), &id_token_row);
+        assert_eq!(response.id_token(), &id_token_raw);
         assert_eq!(response.scope(), "openid email");
         assert_eq!(response.token_type(), "Bearer");
         assert_eq!(response.refresh_token(), &refresh_token);


### PR DESCRIPTION
## Overview
This PR rename a struct  that misspelled.
## Changes
- Rename the struct from `IDTokenRow` to `IDTokenRaw`
- Rename the constructor method from `IDToken::from_id_token_row` to `IDToken::from_id_token_raw`
## Breaking Chnages
The struct `IDTokenRow` has been renamed to `IDTokenRaw` and can no longer be used under its old name.