### PR TITLE
refactor: rename Error::Json to Error::DeserializeJson for clarity

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -15,8 +15,8 @@ pub enum Error {
     ScopeMismatch,
     #[error("Failed to parse url")]
     URL,
-    #[error("Failed to parse JSON")]
-    Json,
+    #[error("Failed to deserialize JSON")]
+    DeserializeJson,
     #[error("Failed to send data")]
     Send,
     #[error("Send request but failed")]

--- a/src/id_token.rs
+++ b/src/id_token.rs
@@ -214,8 +214,8 @@ pub async fn send_id_token_req(req: &IDTokenRequest<'_>) -> Result<IDTokenRespon
     }
 
     let res_json = res.json::<IDTokenResponse>().await.map_err(|e| {
-        error!("Failed to parse JSON: {:?}", e);
-        Error::Json
+        error!("Failed to deserialize JSON: {:?}", e);
+        Error::DeserializeJson
     })?;
     Ok(res_json)
 }

--- a/src/refresh_token.rs
+++ b/src/refresh_token.rs
@@ -137,8 +137,8 @@ pub async fn send_refresh_token_req(
     }
 
     let res_json = res.json::<RefreshTokenResponse>().await.map_err(|e| {
-        error!("Failed to parse JSON: {:?}", e);
-        Error::Json
+        error!("Failed to deserialize JSON: {:?}", e);
+        Error::DeserializeJson
     })?;
     Ok(res_json)
 }


### PR DESCRIPTION
## Overview
The previous name `Json` was ambiguous. This change makes it clear that the error refers specifically to a failure in JSON deserialization.
## Changes
- `Error` enum variant `Json` to `DeserializeJson`
- `send_id_token_req()` function's error log message
- `send_refresh_token_req()` function's error log message 
