### PR TITLE
refactor: rename Error::URL to Error::ParseURL for clarify

### DIFF
--- a/src/code.rs
+++ b/src/code.rs
@@ -196,7 +196,7 @@ impl<'a> CodeRequest<'a> {
             self.state.0,
             self.nonce.0,
         );
-        let url = Url::parse(&url).map_err(|_| Error::URL)?;
+        let url = Url::parse(&url).map_err(|_| Error::ParseURL)?;
         Ok(url)
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,7 +14,7 @@ pub enum Error {
     #[error("Failed to parse url")]
     ScopeMismatch,
     #[error("Failed to parse url")]
-    URL,
+    ParseURL,
     #[error("Failed to deserialize JSON")]
     DeserializeJson,
     #[error("Failed to send data")]

--- a/src/id_token.rs
+++ b/src/id_token.rs
@@ -188,7 +188,7 @@ pub async fn send_id_token_req(req: &IDTokenRequest<'_>) -> Result<IDTokenRespon
 
     let url = Url::parse(req.token_endpoint().value()).map_err(|e| {
         error!("Failed to parse url: {:?}", e);
-        Error::URL
+        Error::ParseURL
     })?;
     let mut params = HashMap::new();
     params.insert("code", req.code().0.as_str());


### PR DESCRIPTION
## Overview
The previous name `URL` was ambiguous. This changes makes it clear that the error refers specifically to a failure in URL parse
## Changes
- Change Error enum valiant from `URL` to `ParseURL`
- Reflect changes into `CodeRequest`'s method and `send_id_tokne_req()` function